### PR TITLE
Minor configuration tweaks to build documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ notifications:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("Example"); Pkg.test("Example"; coverage=true)';
 after_success:
-  - julia -e 'Pkg.add("Documenter")'
+  - julia -e 'Pkg.add.(["Documenter", "Distributions", "Roots", "DataStructures", "Plots", "DataFrames"])'
   - julia -e 'cd(Pkg.dir("pwr")); include(joinpath("docs","make.jl"))'
 #  - julia -e 'cd(Pkg.dir("Example")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
 #  - julia -e 'cd(Pkg.dir("Example")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())';

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,9 @@ using Documenter, pwr
 
 push!(LOAD_PATH,"../src/")
 
-makedocs()
+makedocs(
+    doctest = false
+)
 
 deploydocs(
     deps = Deps.pip("mkdocs", "python-markdown-math"),

--- a/src/pwr.jl
+++ b/src/pwr.jl
@@ -28,8 +28,8 @@ include("PTest.jl")
 include("RTest.jl")
 include("T2nTest.jl")
 include("TTest.jl")
-include("TwoP2nTest.jl")
-include("TwoPTest.jl")
+include("Twop2nTest.jl")
+include("TwopTest.jl")
 include("PowerPlot.jl")
 
 end


### PR DESCRIPTION
A couple of changes to hopefully get the documentation to automatically build on the `gh-pages` branch according to the [guide](https://juliadocs.github.io/Documenter.jl/stable/man/hosting/). Apparently docs will [only be built on master](https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#Final-Remarks) so let's try it there.